### PR TITLE
Add instructions to download data used in lessons and add links to syllabi

### DIFF
--- a/_includes/swc/schedule.html
+++ b/_includes/swc/schedule.html
@@ -3,11 +3,11 @@
     <h3>Day 1</h3>
     <table class="table table-striped">
       <tr> <td>Before</td> <td><a href="{{ site.pre_survey }}{{ site.github.project_title }}" target="_blank" rel="noopener noreferrer">Pre-workshop survey</a> </td> </tr>
-      <tr> <td>09:00</td>  <td>Automating Tasks with the Unix Shell</td> </tr>
+      <tr> <td>09:00</td>  <td><a href="{{site.swc_pages}}/shell-novice">Automating Tasks with the Unix Shell</a></td> </tr>
       <tr> <td>10:30</td>  <td>Morning break</td> </tr>
       <tr> <td>11:00</td>  <td>Automating Tasks with the Unix Shell (Continued)</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
-      <tr> <td>13:00</td>  <td>Plotting and Programming in Python</td> </tr>
+      <tr> <td>13:00</td>  <td><a href="{{site.swc_pages}}/python-novice-gapminder">Plotting and Programming in Python</a></td> </tr>
       <tr> <td>14:30</td>  <td>Afternoon break</td> </tr>
       <tr> <td>15:00</td>  <td>Plotting and Programming in Python (Continued)</td> </tr>
       <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
@@ -17,7 +17,7 @@
   <div class="col-md-6">
     <h3>Day 2</h3>
     <table class="table table-striped">
-      <tr> <td>09:00</td>  <td>Version Control with Git</td> </tr>
+      <tr> <td>09:00</td>  <td><a href="{{site.swc_pages}}/git-novice">Version Control with Git</a></td> </tr>
       <tr> <td>10:30</td>  <td>Morning break</td> </tr>
       <tr> <td>11:00</td>  <td>Version Control with Git (Continued)</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>

--- a/index.md
+++ b/index.md
@@ -445,3 +445,21 @@ Please check the "Setup" page of
 [the lesson site]({{ site.incubator_lesson_site }}) for instructions to follow
 to obtain the software and data you will need to follow the lesson.
 {% endif %}
+
+
+{% if site.curriculum == "swc-gapminder" %}
+<div id="data">
+<h3>Data Used in the Lessons</h3>
+See the following lesson setup instructions to download required data for the lessons:
+
+<ul>
+<li><a href="https://swcarpentry.github.io/shell-novice/setup.html">The UNIX Shell: Setup</a></li>
+
+<li><a href="https://swcarpentry.github.io/python-novice-gapminder/setup.html">Plotting and Programming in Python: Setup</a></li>
+</ul>
+{% endif %}
+
+{% comment %}
+I'm not sure what the correct zip file to download for the R class is...
+{% endcomment %}
+</div>


### PR DESCRIPTION
1. Add instructions to download the data used in the shell and python lessons.
2. Add links to the lesson syllabi in the schedule.

Feel free to cherry-pick only the first commit if you feel we shouldn't publicize the syllabi links.

